### PR TITLE
Split imports into logical groups

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -6,6 +6,7 @@ package btcchain
 
 import (
 	"fmt"
+
 	"github.com/conformal/btcutil"
 )
 

--- a/chain.go
+++ b/chain.go
@@ -8,14 +8,15 @@ import (
 	"container/list"
 	"errors"
 	"fmt"
-	"github.com/conformal/btcdb"
-	"github.com/conformal/btcnet"
-	"github.com/conformal/btcutil"
-	"github.com/conformal/btcwire"
 	"math/big"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/conformal/btcdb"
+	"github.com/conformal/btcnet"
+	"github.com/conformal/btcutil"
+	"github.com/conformal/btcwire"
 )
 
 const (

--- a/chain_test.go
+++ b/chain_test.go
@@ -5,11 +5,12 @@
 package btcchain_test
 
 import (
+	"testing"
+
 	"github.com/conformal/btcchain"
 	"github.com/conformal/btcnet"
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
-	"testing"
 )
 
 // TestHaveBlock tests the HaveBlock API to ensure proper functionality.

--- a/checkpoints.go
+++ b/checkpoints.go
@@ -6,6 +6,7 @@ package btcchain
 
 import (
 	"fmt"
+
 	"github.com/conformal/btcnet"
 	"github.com/conformal/btcscript"
 	"github.com/conformal/btcutil"

--- a/common_test.go
+++ b/common_test.go
@@ -6,14 +6,15 @@ package btcchain_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/conformal/btcchain"
 	"github.com/conformal/btcdb"
 	_ "github.com/conformal/btcdb/ldb"
 	_ "github.com/conformal/btcdb/memdb"
 	"github.com/conformal/btcnet"
 	"github.com/conformal/btcutil"
-	"os"
-	"path/filepath"
 )
 
 // testDbType is the database backend type to use for the tests.

--- a/difficulty.go
+++ b/difficulty.go
@@ -6,9 +6,10 @@ package btcchain
 
 import (
 	"fmt"
-	"github.com/conformal/btcwire"
 	"math/big"
 	"time"
+
+	"github.com/conformal/btcwire"
 )
 
 const (

--- a/difficulty_test.go
+++ b/difficulty_test.go
@@ -5,9 +5,10 @@
 package btcchain_test
 
 import (
-	"github.com/conformal/btcchain"
 	"math/big"
 	"testing"
+
+	"github.com/conformal/btcchain"
 )
 
 func TestBigToCompact(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -5,8 +5,9 @@
 package btcchain_test
 
 import (
-	"github.com/conformal/btcchain"
 	"testing"
+
+	"github.com/conformal/btcchain"
 )
 
 // TestErrorCodeStringer tests the stringized output for the ErrorCode type.

--- a/internal_test.go
+++ b/internal_test.go
@@ -12,8 +12,9 @@ interface.  The functions are only exported while the tests are being run.
 package btcchain
 
 import (
-	"github.com/conformal/btcutil"
 	"time"
+
+	"github.com/conformal/btcutil"
 )
 
 // TstSetCoinbaseMaturity makes the ability to set the coinbase maturity

--- a/log.go
+++ b/log.go
@@ -6,8 +6,9 @@ package btcchain
 
 import (
 	"errors"
-	"github.com/conformal/btclog"
 	"io"
+
+	"github.com/conformal/btclog"
 )
 
 // log is a logger that is initialized with no output filters.  This

--- a/merkle.go
+++ b/merkle.go
@@ -5,9 +5,10 @@
 package btcchain
 
 import (
+	"math"
+
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
-	"math"
 )
 
 // nextPowerOfTwo returns the next highest power of two from a given number if

--- a/merkle_test.go
+++ b/merkle_test.go
@@ -5,9 +5,10 @@
 package btcchain_test
 
 import (
+	"testing"
+
 	"github.com/conformal/btcchain"
 	"github.com/conformal/btcutil"
-	"testing"
 )
 
 // TestMerkle tests the BuildMerkleTreeStore API.

--- a/process.go
+++ b/process.go
@@ -6,6 +6,7 @@ package btcchain
 
 import (
 	"fmt"
+
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
 )

--- a/reorganization_test.go
+++ b/reorganization_test.go
@@ -7,14 +7,15 @@ package btcchain_test
 import (
 	"compress/bzip2"
 	"encoding/binary"
-	"github.com/conformal/btcchain"
-	"github.com/conformal/btcutil"
-	"github.com/conformal/btcwire"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/conformal/btcchain"
+	"github.com/conformal/btcutil"
+	"github.com/conformal/btcwire"
 )
 
 // TestReorganization loads a set of test blocks which force a chain

--- a/scriptval.go
+++ b/scriptval.go
@@ -6,11 +6,12 @@ package btcchain
 
 import (
 	"fmt"
+	"math"
+	"runtime"
+
 	"github.com/conformal/btcscript"
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
-	"math"
-	"runtime"
 )
 
 // txValidateItem holds a transaction along with which input to validate.

--- a/timesorter_test.go
+++ b/timesorter_test.go
@@ -5,11 +5,12 @@
 package btcchain_test
 
 import (
-	"github.com/conformal/btcchain"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/conformal/btcchain"
 )
 
 // TestTimeSorter tests the timeSorter implementation.

--- a/txlookup.go
+++ b/txlookup.go
@@ -6,6 +6,7 @@ package btcchain
 
 import (
 	"fmt"
+
 	"github.com/conformal/btcdb"
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"

--- a/validate.go
+++ b/validate.go
@@ -7,14 +7,15 @@ package btcchain
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
+	"math/big"
+	"time"
+
 	"github.com/conformal/btcdb"
 	"github.com/conformal/btcnet"
 	"github.com/conformal/btcscript"
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
-	"math"
-	"math/big"
-	"time"
 )
 
 const (

--- a/validate_test.go
+++ b/validate_test.go
@@ -5,14 +5,15 @@
 package btcchain_test
 
 import (
-	"github.com/conformal/btcchain"
-	"github.com/conformal/btcnet"
-	"github.com/conformal/btcutil"
-	"github.com/conformal/btcwire"
 	"math"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/conformal/btcchain"
+	"github.com/conformal/btcnet"
+	"github.com/conformal/btcutil"
+	"github.com/conformal/btcwire"
 )
 
 // TestCheckConnectBlock tests the CheckConnectBlock function to ensure it


### PR DESCRIPTION
This change set is result of running goimports -w . on the whole repository.
It's considered a good practice to separate stdlib imports from external imports.
